### PR TITLE
add an initialize method, so we explicitly do nothing by default

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "ops@modcloth.com"
 license          "Apache 2.0"
 description      "Allows delegation of service management to users with Solaris Role Based Access Control (RBAC)"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
-version          "0.0.2"
+version          "0.0.3"
 
 supports "solaris"
 supports "smartos"

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -9,3 +9,8 @@ end
 def self.definitions
   @definitions ||= []
 end
+
+def intialize(*args)
+  super(*args)
+  @action = :nothing
+end


### PR DESCRIPTION
- attempts to fix an issue in ruby 1.9.2 with super called on a
  metaclass

If you don't explicitly define initialize on the resource, the cascade of supers calling supers gets reeeeeeally weird inside of chef, and is very dependent on what version of ruby you are in.
